### PR TITLE
feat: Textarea 컴포넌트 구현

### DIFF
--- a/packages/design-system/.storybook/styles/styles.ts
+++ b/packages/design-system/.storybook/styles/styles.ts
@@ -92,4 +92,13 @@ export const classStyles = css`
   .Input-case {
     width: 100px;
   }
+
+  /** Inputs > Textarea */
+  .Textarea-container {
+    width: 480px;
+  }
+
+  .Textarea-case {
+    width: 100px;
+  }
 `;

--- a/packages/design-system/src/components/Inputs/Input/Input.tsx
+++ b/packages/design-system/src/components/Inputs/Input/Input.tsx
@@ -19,7 +19,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     id,
     type = 'text',
     defaultValue,
-    placeholder,
     disabled,
     onChange,
     onFocus,
@@ -66,7 +65,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         id={id}
         ref={ref}
         type={type}
-        placeholder={placeholder}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...(isControlled

--- a/packages/design-system/src/components/Inputs/Textarea/Textarea.stories.tsx
+++ b/packages/design-system/src/components/Inputs/Textarea/Textarea.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { Story, Meta } from '@storybook/react';
-import { FormEvent, MouseEvent, useRef } from 'react';
+import { ChangeEvent, FormEvent, MouseEvent, useState } from 'react';
 
 import Textarea, { TextareaProps } from './Textarea';
 import { HStack, VStack } from '../../Layout';
@@ -61,38 +61,44 @@ TextareaStates.argTypes = {
   },
 };
 
-export const WithButton = (args: TextareaProps) => {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+export const ControlledWithButton = (args: TextareaProps) => {
+  const [textValue, setTextValue] = useState<string>('');
+  const [isButtonDisabled, setButtonDisabled] = useState<boolean>(true);
 
   const handleCancel = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
 
-    if (textareaRef.current) {
-      textareaRef.current.value = '';
-    }
+    setTextValue('');
   };
 
-  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.target;
+
+    setTextValue(value);
+    setButtonDisabled(value.length < 1);
   };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.log(e);
-    console.log(textareaRef?.current?.value);
+    console.log(textValue);
   };
 
   return (
     <form className="Textarea-container" onSubmit={handleSubmit}>
       <Textarea
         {...args}
-        ref={textareaRef}
-        defaultValue=""
+        controlledValue={textValue}
+        onChange={handleChange}
         buttons={[
-          <button type="button" onClick={handleCancel}>
+          <button
+            type="button"
+            disabled={isButtonDisabled}
+            onClick={handleCancel}
+          >
             Cancel
           </button>,
-          <button type="submit" onClick={handleClick}>
+          <button type="submit" disabled={isButtonDisabled}>
             Submit
           </button>,
         ]}

--- a/packages/design-system/src/components/Inputs/Textarea/Textarea.stories.tsx
+++ b/packages/design-system/src/components/Inputs/Textarea/Textarea.stories.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource @emotion/react */
+import { Story, Meta } from '@storybook/react';
+import { FormEvent, MouseEvent, useRef } from 'react';
+
+import Textarea, { TextareaProps } from './Textarea';
+import { HStack, VStack } from '../../Layout';
+import { Paragraph } from '../../Base';
+
+export default {
+  title: 'Inputs / Textarea',
+  components: Textarea,
+  args: {
+    placeholder: '내용을 입력하세요',
+  },
+} as Meta;
+
+const TextareaBase: Story<TextareaProps> = (args) => {
+  return (
+    <div className="Textarea-container">
+      <Textarea {...args} />
+    </div>
+  );
+};
+
+export const Base = TextareaBase.bind({});
+
+export const TextareaStates = (args: TextareaProps) => {
+  return (
+    <VStack>
+      <HStack alignItems="center" mb={20}>
+        <Paragraph type="3" className="Textarea-case">
+          initial
+        </Paragraph>
+        <Base {...args} />
+      </HStack>
+      <HStack alignItems="center" mb={20}>
+        <Paragraph type="3" className="Textarea-case">
+          focused
+        </Paragraph>
+        <Base {...args} defaultValue="내용 입력 중" autoFocus />
+      </HStack>
+      <HStack alignItems="center" mb={20}>
+        <Paragraph type="3" className="Textarea-case">
+          blurred
+        </Paragraph>
+        <Base {...args} defaultValue="내용 입력" />
+      </HStack>
+      <HStack alignItems="center" mb={20}>
+        <Paragraph type="3" className="Textarea-case">
+          disabled
+        </Paragraph>
+        <Base {...args} defaultValue="내용 입력" disabled />
+      </HStack>
+    </VStack>
+  );
+};
+// autoFocus 케이스로 인해 args값이 변경될시 canvas로 포커스가 강제 이동되는 이슈가 있어 disable처리
+TextareaStates.argTypes = {
+  placeholder: {
+    table: { disable: true },
+  },
+};
+
+export const WithButton = (args: TextareaProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleCancel = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+
+    if (textareaRef.current) {
+      textareaRef.current.value = '';
+    }
+  };
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log(e);
+    console.log(textareaRef?.current?.value);
+  };
+
+  return (
+    <form className="Textarea-container" onSubmit={handleSubmit}>
+      <Textarea
+        {...args}
+        ref={textareaRef}
+        defaultValue=""
+        buttons={[
+          <button type="button" onClick={handleCancel}>
+            Cancel
+          </button>,
+          <button type="submit" onClick={handleClick}>
+            Submit
+          </button>,
+        ]}
+      />
+    </form>
+  );
+};

--- a/packages/design-system/src/components/Inputs/Textarea/Textarea.style.ts
+++ b/packages/design-system/src/components/Inputs/Textarea/Textarea.style.ts
@@ -41,9 +41,3 @@ export const textarea = css`
     color: var(--grey-4);
   }
 `;
-
-export const buttonContainer = css`
-  & > *:not(:last-of-type) {
-    margin-right: 16px;
-  }
-`;

--- a/packages/design-system/src/components/Inputs/Textarea/Textarea.style.ts
+++ b/packages/design-system/src/components/Inputs/Textarea/Textarea.style.ts
@@ -1,0 +1,49 @@
+import { css } from '@emotion/react';
+
+export const container = css`
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  color: var(--black);
+  padding: 14px 18px;
+  border: 1px solid var(--grey-4);
+  border-radius: 8px;
+`;
+
+export const focused = css`
+  border: 1px solid var(--black);
+`;
+
+export const disabled = css`
+  color: var(--grey-5);
+  background-color: var(--grey-2);
+  border: 1px solid var(--grey-2);
+
+  & > textarea {
+    color: var(--grey-5);
+  }
+`;
+
+export const textarea = css`
+  width: 100%;
+  min-height: 56px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 28px;
+  letter-spacing: -0.6px;
+  padding: 0;
+  outline: none;
+  border: none;
+  background: transparent;
+
+  &::placeholder {
+    color: var(--grey-4);
+  }
+`;
+
+export const buttonContainer = css`
+  & > *:not(:last-of-type) {
+    margin-right: 16px;
+  }
+`;

--- a/packages/design-system/src/components/Inputs/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Inputs/Textarea/Textarea.tsx
@@ -65,11 +65,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           {...restProps}
         />
         {hasButtons && (
-          <HStack
-            css={styles.buttonContainer}
-            justifyContent="flex-end"
-            mt={16}
-          >
+          <HStack justifyContent="flex-end" gap={16} mt={16}>
             {Children.toArray(buttons.map((button) => cloneElement(button)))}
           </HStack>
         )}

--- a/packages/design-system/src/components/Inputs/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Inputs/Textarea/Textarea.tsx
@@ -1,0 +1,81 @@
+/** @jsxImportSource @emotion/react */
+import {
+  forwardRef,
+  TextareaHTMLAttributes,
+  useState,
+  ReactElement,
+  Children,
+  cloneElement,
+  useEffect,
+} from 'react';
+import classNames from 'classnames';
+
+import { HStack } from '../../Layout';
+import { useClickOutside } from '../../../hooks';
+
+import * as styles from './Textarea.style';
+
+export interface TextareaProps
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'css' | 'value'> {
+  controlledValue?: string | number | readonly string[];
+  buttons?: ReactElement[];
+  className?: string;
+}
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  function Textarea(
+    {
+      className,
+      defaultValue,
+      disabled,
+      onChange,
+      controlledValue,
+      buttons = [],
+      ...restProps
+    },
+    ref,
+  ) {
+    const { ref: containreRef, isOutside } = useClickOutside();
+    const [isFocused, setFocused] = useState<boolean>(false);
+
+    const isControlled = Boolean(onChange);
+    const isDisabled = Boolean(disabled);
+    const hasButtons = Boolean(buttons.length);
+
+    useEffect(() => {
+      setFocused(!isOutside);
+    }, [isOutside]);
+
+    return (
+      <div
+        ref={containreRef}
+        className={classNames('hermes-textarea-container', className)}
+        css={[
+          styles.container,
+          isFocused && styles.focused,
+          isDisabled && styles.disabled,
+        ]}
+      >
+        <textarea
+          css={styles.textarea}
+          ref={ref}
+          {...(isControlled
+            ? { value: controlledValue, onChange }
+            : { defaultValue })}
+          {...restProps}
+        />
+        {hasButtons && (
+          <HStack
+            css={styles.buttonContainer}
+            justifyContent="flex-end"
+            mt={16}
+          >
+            {Children.toArray(buttons.map((button) => cloneElement(button)))}
+          </HStack>
+        )}
+      </div>
+    );
+  },
+);
+
+export default Textarea;

--- a/packages/design-system/src/components/Inputs/Textarea/index.ts
+++ b/packages/design-system/src/components/Inputs/Textarea/index.ts
@@ -1,0 +1,4 @@
+import { TextareaProps } from './Textarea';
+
+export type { TextareaProps };
+export { default as Textarea } from './Textarea';

--- a/packages/design-system/src/components/Inputs/index.ts
+++ b/packages/design-system/src/components/Inputs/index.ts
@@ -1,1 +1,2 @@
 export * from './Input';
+export * from './Textarea';

--- a/packages/design-system/src/hooks/index.ts
+++ b/packages/design-system/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useClickOutside } from './useClickOutside';

--- a/packages/design-system/src/hooks/useClickOutside.ts
+++ b/packages/design-system/src/hooks/useClickOutside.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export default function useClickOutside(callback?: (event?: Event) => void) {
+  const [isOutside, setIsOutside] = useState(true);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = useCallback(
+    (event: Event) => {
+      const eventTarget = event.target as Node;
+      let isOutsideFlag = true;
+
+      if (ref?.current === eventTarget || ref?.current?.contains(eventTarget)) {
+        isOutsideFlag = false;
+      }
+
+      setIsOutside(isOutsideFlag);
+
+      if (isOutsideFlag) {
+        callback?.(event);
+      }
+    },
+    [callback],
+  );
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside, true);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  }, [handleClickOutside]);
+
+  return { ref, isOutside };
+}


### PR DESCRIPTION
### Issue
Textarea 컴포넌트 구현 #12 

### Changes
Inputs 카테고리 내에 Textarea 컴포넌트 및 스토리 추가
- textarea
  - controlled, uncontrolled 케이스에 둘다 대응 가능하도록 구현하였습니다.
    - controlled일 경우 value 대신 controlledValue 와 onChange 전달
    - uncontrolled일 경우 defaultValue 전달
- buttons
  - 필요한 버튼 엘리먼트를 사용처에서 전달할 수 있습니다. 스토리북 `With Button` 케이스에서 확인 가능합니다.
- 시안상 정의되어 있는 initial/focused/blurred/disabled 케이스 스토리북에서 확인 가능합니다.
- focus/blur 제어를 textarea 뿐만 아니라 container 전체에 대해 적용해야 해서 `useClickOutside` 훅 추가하여 관련 기능 구현하였습니다.

### Test Cases
- [x] 스토리북 UI 테스트

### Notes
- textarea 의 높이 조정 여부에 대해 디자인 문의할 예정
- base 브랜치는 input이 먼저 머지된 후에 epic 브랜치로 수정할 예정

### Screen Shots
![image](https://user-images.githubusercontent.com/51347549/141651154-70d967f6-4dbb-40fc-bf5e-a4b97da4a9de.png)

### Post Actions
Checkbox 구현
