### PR TITLE
feat: Toggle 컴포넌트 구현

### DIFF
--- a/packages/design-system/src/components/Inputs/Toggle/Toggle.stories.tsx
+++ b/packages/design-system/src/components/Inputs/Toggle/Toggle.stories.tsx
@@ -1,0 +1,27 @@
+/** @jsxImportSource @emotion/react */
+import { Story, Meta } from '@storybook/react';
+import { ChangeEvent } from 'react';
+
+import Toggle, { ToggleProps } from './Toggle';
+
+export default {
+  title: 'Inputs / Toggle',
+  components: Toggle,
+  args: {
+    label: '이어쓰기 모드',
+  },
+} as Meta;
+
+const ToggleBase: Story<ToggleProps> = (args) => {
+  const { id = 'base', ...restArgs } = args;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    // console.log(e.target.checked);
+  };
+
+  return (
+    <Toggle {...restArgs} id={id} defaultChecked onChange={handleChange} />
+  );
+};
+
+export const Base = ToggleBase.bind({});

--- a/packages/design-system/src/components/Inputs/Toggle/Toggle.style.ts
+++ b/packages/design-system/src/components/Inputs/Toggle/Toggle.style.ts
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react';
+
+export const container = css`
+  display: flex;
+  align-items: center;
+`;
+
+export const toggle = css`
+  position: relative;
+  width: 40px;
+  height: 24px;
+  background-color: var(--grey-3);
+  border-radius: 12px;
+  transition: background-color 0.15s ease-in-out;
+`;
+
+export const checked = css`
+  background-color: var(--grey-12);
+
+  & > div {
+    transform: translateX(0);
+  }
+`;
+
+export const indicator = css`
+  width: 20px;
+  height: 20px;
+  background-color: var(--white);
+  border-radius: 50%;
+  margin: 2px;
+  transform: translateX(16px);
+  transition: transform 0.15s ease-in-out;
+`;
+
+export const input = css`
+  cursor: pointer;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  opacity: 0;
+  z-index: 1;
+`;
+
+export const label = css`
+  color: var(--black);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 28px;
+  letter-spacing: -0.6;
+  margin-left: 8px;
+`;

--- a/packages/design-system/src/components/Inputs/Toggle/Toggle.tsx
+++ b/packages/design-system/src/components/Inputs/Toggle/Toggle.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource @emotion/react */
+import {
+  ChangeEvent,
+  forwardRef,
+  InputHTMLAttributes,
+  useEffect,
+  useState,
+} from 'react';
+import classNames from 'classnames';
+
+import * as styles from './Toggle.style';
+
+export interface ToggleProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'css' | 'checked'> {
+  label?: string;
+}
+
+const Toggle = forwardRef<HTMLInputElement, ToggleProps>(function Toggle(
+  { id, label, className, defaultChecked = false, onChange, ...restProps },
+  ref,
+) {
+  const [checked, setChecked] = useState<boolean>(defaultChecked);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(e);
+    setChecked(e.target.checked);
+  };
+
+  useEffect(() => {
+    setChecked(defaultChecked);
+  }, [defaultChecked]);
+
+  return (
+    <div
+      css={styles.container}
+      className={classNames('hermes-toggle-container', className)}
+    >
+      <div css={[styles.toggle, checked && styles.checked]}>
+        <div css={styles.indicator} />
+        <input
+          css={styles.input}
+          type="checkbox"
+          ref={ref}
+          id={id}
+          checked={checked}
+          onChange={handleChange}
+          {...restProps}
+        />
+      </div>
+      {Boolean(label) && (
+        <label css={styles.label} htmlFor={id}>
+          {label}
+        </label>
+      )}
+    </div>
+  );
+});
+
+export default Toggle;

--- a/packages/design-system/src/components/Inputs/Toggle/index.ts
+++ b/packages/design-system/src/components/Inputs/Toggle/index.ts
@@ -1,0 +1,4 @@
+import { ToggleProps } from './Toggle';
+
+export type { ToggleProps };
+export { default as Toggle } from './Toggle';

--- a/packages/design-system/src/components/Inputs/index.ts
+++ b/packages/design-system/src/components/Inputs/index.ts
@@ -1,3 +1,4 @@
 export * from './Input';
 export * from './Textarea';
 export * from './Checkbox';
+export * from './Toggle';


### PR DESCRIPTION
### Issue
Toggle 컴포넌트 구현 #12 

### Changes
- Toggle 컴포넌트 및 스토리북 추가하였습니다.
  - Checkbox와 내부 로직은 거의 비슷합니다.
  - variation이 다양하지는 않아서 Base 스토리만 구현되었습니다.

### Test Cases
- [x] 스토리북 UI 테스트

### Screen Shots
![image](https://user-images.githubusercontent.com/51347549/141984341-ad7abb4a-8e6d-4ce4-93c3-d0ded60cac11.png)

### Post Actions
Selects 카테고리 구현
